### PR TITLE
Gitlab Backend Working

### DIFF
--- a/org-sync-gitlab.el
+++ b/org-sync-gitlab.el
@@ -83,6 +83,10 @@
     :id ,(assoc-default `id  data)
 	:title ,(assoc-default `title data)
 	:status, (if (string= (assoc-default `state data) "opened") 'open 'closed)
+	:date-creation ,(org-sync-parse-date (assoc-default 'created_at data))
+	:deadline ,(org-sync-parse-date (assoc-default 'due_date data))
+	:date-modification ,(org-sync-parse-date (assoc-default 'updated_at data))
+	:web-url ,(assoc-default 'web_url data)
 	:desc, (assoc-default `description data)))
 
 

--- a/org-sync-gitlab.el
+++ b/org-sync-gitlab.el
@@ -43,11 +43,18 @@
     (send-buglist  . org-sync-gitlab-send-buglist))
   "Gitlab backend.")
 
+(defvar org-sync-gitlab-domain
+  "gitlab.com"
+  "The domain for gitlab.")
+
 ;; override
 (defun org-sync-gitlab-base-url (url)
   "Return base URL."
   ;;TODO impliment org-sync-gitlab-base-url
-  (nil))
+  (string-match (concat  org-sync-gitlab-domain "/\\([^/]+\\)/\\([^/]+\\)/?$")  url)
+  (concat "https://" org-sync-gitlab-domain "/api/v4/projects/"
+           (match-string 1 url) "%2F" (match-string 2 url) "/" ))
+
 
 ;; override
 (defun org-sync-gitlab-fetch-buglist (last-update)

--- a/org-sync-gitlab.el
+++ b/org-sync-gitlab.el
@@ -106,8 +106,8 @@
        '(nil))))
   ;;brute force update bugs
   ;;TODO be smarter and only show updated bugs
-  (org-sync-gitlab-fetch-bugs (org-sync-get-prop :since
-						 buglist))
+  `(:bugs ,(org-sync-gitlab-fetch-bugs (org-sync-get-prop :since
+					       buglist)))
   )
 
 

--- a/org-sync-gitlab.el
+++ b/org-sync-gitlab.el
@@ -83,7 +83,6 @@
 ;; override
 (defun org-sync-gitlab-send-buglist (buglist)
   "Send a  BUGLIST to the git lab and return updated BUGLIST."
-  ;;TODO impliment org-sync-gitlab-send-buglist
   (dolist (b (org-sync-get-prop :bugs buglist))
     (let*
 	(
@@ -91,6 +90,10 @@
 	 (escapedTitle (url-hexify-string (org-sync-get-prop :title b)))
 	 (escapedDesc (url-hexify-string (org-sync-get-prop :desc b)))
 	 (issuePath (concat "/issues/" (if id (number-to-string id ))))
+	 (issueDataQueryString (concat
+				"?title="   escapedTitle
+				"&description=" escapedDesc
+				))
 	 )
       (cond
        ;; new bug (no id)
@@ -99,8 +102,7 @@
 	 "POST"
 	 (concat (org-sync-gitlab-api-url)
 		 issuePath
-		 "?title="   escapedTitle
-		 "&description=" escapedDesc)))
+		 issueDataQueryString)))
 
        ;; delete bug
        ((org-sync-get-prop :delete b)
@@ -112,7 +114,13 @@
 
        ;; else, modified bug
        (t
-	'(nil)))))
+	(org-sync-gitlab-request
+	 "PUT"
+	 (concat (org-sync-gitlab-api-url)
+		 issuePath
+		 issueDataQueryString))))
+      )
+    )
   ;;brute force update bugs
   ;;TODO be smarter and only show updated bugs
   `(:bugs ,(org-sync-gitlab-fetch-bugs (org-sync-get-prop :since

--- a/org-sync-gitlab.el
+++ b/org-sync-gitlab.el
@@ -82,9 +82,34 @@
 
 ;; override
 (defun org-sync-gitlab-send-buglist (buglist)
-  "Send a  BUGLIST to the bugtracker and return new bugs"
+  "Send a  BUGLIST to the git lab and return updated BUGLIST."
   ;;TODO impliment org-sync-gitlab-send-buglist
-  nil)
+  (org-sync-get-prop :bugs buglist)
+  (dolist (b (org-sync-get-prop :bugs buglist))
+    b
+    (cond
+      ;; new bug (no id)
+      ((null (org-sync-get-prop :id b))
+	       (org-sync-gitlab-request
+		"POST"
+		(concat (org-sync-gitlab-api-url)
+			"/issues/" ;; (org-sync-get-prop :id b )
+			"?title="   (url-hexify-string (org-sync-get-prop :title b))
+			"&description=" (url-hexify-string (org-sync-get-prop :desc b)))))
+
+      ;; delete bug
+      ((org-sync-get-prop :delete b)
+        '(nil))
+
+      ;; else, modified bug
+      (t
+       '(nil))))
+  ;;brute force update bugs
+  ;;TODO be smarter and only show updated bugs
+  (org-sync-gitlab-fetch-bugs (org-sync-get-prop :since
+						 buglist))
+  )
+
 
 (defun org-sync-gitlab-json-to-bug (data)
   "Convert the provided Json DATA into a bug."

--- a/org-sync-gitlab.el
+++ b/org-sync-gitlab.el
@@ -64,16 +64,21 @@
   "Return the buglist at org-sync-base-url."
   ;;TODO implement SINCE
   ;;TODO get name for task list from url 
-  (let
-      ((jsonBugs (org-sync-gitlab-request
-	      "GET"
-	      (concat (org-sync-gitlab-api-url) "issues?per_page=100"))))
   `(:title "Tasks"
 	   :url ,org-sync-base-url
-	   :bugs ,(mapcar 'org-sync-gitlab-json-to-bug jsonBugs)
-    )))
+	   :bugs ,(org-sync-gitlab-fetch-bugs last-update)
+    ))
 
-
+(defun org-sync-gitlab-fetch-bugs (last-update)
+  "Return the json bugs."
+  ;;TODO impliment LAST-UPDATE
+  (let
+      ((jsonBugs (org-sync-gitlab-request
+		  "GET"
+		  (concat (org-sync-gitlab-api-url) "issues?per_page=100"))))
+    (mapcar 'org-sync-gitlab-json-to-bug jsonBugs)
+    )
+  )
 
 ;; override
 (defun org-sync-gitlab-send-buglist (buglist)

--- a/org-sync-gitlab.el
+++ b/org-sync-gitlab.el
@@ -89,7 +89,7 @@
 (defun org-sync-gitlab-json-to-bug (data)
   "Convert the provided Json DATA into a bug."
   `(
-    :id ,(assoc-default `id  data)
+    :id ,(assoc-default `iid  data) ;; iid is the internal issue id, used for updating
 	:title ,(assoc-default `title data)
 	:status, (if (string= (assoc-default `state data) "opened") 'open 'closed)
 	:date-creation ,(org-sync-parse-date (assoc-default 'created_at data))

--- a/org-sync-gitlab.el
+++ b/org-sync-gitlab.el
@@ -1,0 +1,67 @@
+;;; org-sync-gitlab --- Gitalab backend for org-sync
+;;
+;; Copyright (C) 2017  Yisrael Dov Lebow
+;;
+;; Author:  Yisrael Dov Lebow <lebow at lebowtech dot com>
+;; Keywords: org, gitlab, synchronization
+;; Homepage: https://github.com/yisraeldov/org-sync
+;;
+;; This program is free software; you can redistribute it and/or modify
+;; it under the terms of the GNU General Public License as published by
+;; the Free Software Foundation, either version 3 of the License, or
+;; (at your option) any later version.
+;;
+;; This program is distributed in the hope that it will be useful,
+;; but WITHOUT ANY WARRANTY; without even the implied warranty of
+;; MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+;; GNU General Public License for more details.
+;;
+;; This file is not part of GNU Emacs.
+;;
+;; You should have received a copy of the GNU General Public License
+;; along with this program.  If not, see <http://www.gnu.org/licenses/>.
+;;
+;;; Commentary:
+;; This package implements a backend for org-sync to synchnonize
+;; issues from a bitbucket repo with an org-mode buffer.  Read
+;; Org-sync documentation for more information about it.
+;;
+;; This backend only supports basic synchronization for now.
+;; Components, versions and milestones are ignored.
+;;
+;;; Code:
+
+
+(eval-when-compile (require 'cl))
+(require 'org-sync)
+(require 'url)
+(require 'json)
+
+(defvar org-sync-gitlab-backend
+  '((base-url      . org-sync-gitlab-base-url)
+    (fetch-buglist . org-sync-gitlab-fetch-buglist)
+    (send-buglist  . org-sync-gitlab-send-buglist))
+  "Gitlab backend.")
+
+;; override
+(defun org-sync-gitlab-base-url (url)
+  "Return base URL."
+  ;;TODO impliment org-sync-gitlab-base-url
+  (nil))
+
+;; override
+(defun org-sync-gitlab-fetch-buglist (last-update)
+  "Return the buglist at org-sync-base-url."
+  ;;TODO implement org-sync-gitlab-fetch-buglist
+  (nil))
+
+;; override
+(defun org-sync-gitlab-send-buglist (buglist)
+  "Send a  BUGLIST to the bugtracker and return new bugs"
+  ;;TODO impliment org-sync-gitlab-send-buglist
+  (nil))
+
+(provide 'org-sync-gitlab)
+;;; org-sync-gitlab ends here
+
+

--- a/org-sync-gitlab.el
+++ b/org-sync-gitlab.el
@@ -22,13 +22,17 @@
 ;; along with this program.  If not, see <http://www.gnu.org/licenses/>.
 ;;
 ;;; Commentary:
-;; This package implements a backend for org-sync to synchnonize
+;; This package implements a gitlab backend for org-sync to synchnonize
 ;; issues from a bitbucket repo with an org-mode buffer.  Read
 ;; Org-sync documentation for more information about it.
 ;;
 ;; This backend only supports basic synchronization for now.
 ;; Components, versions and milestones are ignored.
 ;;
+;; You must set the org-sync-gitlab-auth-token before you can sync.
+;;
+;; If you are not using 'gitlab.com' you can change the domain with
+;; org-sync-gitlab-domain
 ;;; Code:
 
 

--- a/org-sync-gitlab.el
+++ b/org-sync-gitlab.el
@@ -50,7 +50,6 @@
 ;; override
 (defun org-sync-gitlab-base-url (url)
   "Return base URL."
-  ;;TODO impliment org-sync-gitlab-base-url
   (string-match (concat  org-sync-gitlab-domain "/\\([^/]+\\)/\\([^/]+\\)/?$")  url)
   (concat "https://" org-sync-gitlab-domain "/api/v4/projects/"
            (match-string 1 url) "%2F" (match-string 2 url) "/" ))
@@ -59,7 +58,8 @@
 ;; override
 (defun org-sync-gitlab-fetch-buglist (last-update)
   "Return the buglist at org-sync-base-url."
-  ;;TODO implement org-sync-gitlab-fetch-buglist
+  ;;TODO implement SINCE
+  ;;TODO get name for task list from url 
   (let
       ((jsonBugs (org-sync-gitlab-request
 	      "GET"

--- a/org-sync-gitlab.el
+++ b/org-sync-gitlab.el
@@ -60,13 +60,31 @@
 (defun org-sync-gitlab-fetch-buglist (last-update)
   "Return the buglist at org-sync-base-url."
   ;;TODO implement org-sync-gitlab-fetch-buglist
-  (nil))
+  (let
+      ((jsonBugs (org-sync-gitlab-request
+	      "GET"
+	      (concat org-sync-base-url "issues?per_page=100"))))
+  `(:title "Tasks"
+	   :url ,org-sync-base-url
+	   :bugs ,(mapcar 'org-sync-gitlab-json-to-bug jsonBugs)
+    )))
+
+
 
 ;; override
 (defun org-sync-gitlab-send-buglist (buglist)
   "Send a  BUGLIST to the bugtracker and return new bugs"
   ;;TODO impliment org-sync-gitlab-send-buglist
-  (nil))
+  nil)
+
+(defun org-sync-gitlab-json-to-bug (data)
+  "Convert the provided Json DATA into a bug."
+  `(
+    :id ,(assoc-default `id  data)
+	:title ,(assoc-default `title data)
+	:status, (if (string= (assoc-default `state data) "opened") 'open 'closed)
+	:desc, (assoc-default `description data)))
+
 
 (defun org-sync-gitlab-request (method url &optional data)
   "Sends HTTP request at URL using METHOD with DATA

--- a/org-sync-gitlab.el
+++ b/org-sync-gitlab.el
@@ -68,6 +68,26 @@
   ;;TODO impliment org-sync-gitlab-send-buglist
   (nil))
 
+(defun org-sync-gitlab-request (method url &optional data)
+  "Sends HTTP request at URL using METHOD with DATA
+Return a JSON response"
+  (let* ((url-request-method method)
+         (url-request-data data)
+	 (url-request-extra-headers `(( "Private-Token".  ,(org-sync-gitlab-get-auth-token))))
+	 )
+    (message "%s %s %s" method url (prin1-to-string data))
+    (with-current-buffer (url-retrieve-synchronously url)
+      (goto-char url-http-end-of-headers)
+      (prog1 (json-read) (kill-buffer)))))
+
+(defun org-sync-gitlab-get-auth-token ()
+  "Gets the private-token."
+  ;;TODO: prompt the user for auth token
+  (unless  org-sync-gitlab-auth-token
+    (error "Please set org-sync-gitlab-auth-token"))
+  org-sync-gitlab-auth-token
+  )
+
 (provide 'org-sync-gitlab)
 ;;; org-sync-gitlab ends here
 

--- a/org-sync-gitlab.el
+++ b/org-sync-gitlab.el
@@ -50,10 +50,14 @@
 ;; override
 (defun org-sync-gitlab-base-url (url)
   "Return base URL."
-  (string-match (concat  org-sync-gitlab-domain "/\\([^/]+\\)/\\([^/]+\\)/?$")  url)
-  (concat "https://" org-sync-gitlab-domain "/api/v4/projects/"
-           (match-string 1 url) "%2F" (match-string 2 url) "/" ))
+  url)
 
+(defun org-sync-gitlab-api-url ()
+  "Gets the api url from the base-url"
+  (let ((url org-sync-base-url))
+    (string-match (concat  org-sync-gitlab-domain "/\\([^/]+\\)/\\([^/]+\\)/?$")  url)
+    (concat "https://" org-sync-gitlab-domain "/api/v4/projects/"
+	    (match-string 1 url) "%2F" (match-string 2 url) "/" )))
 
 ;; override
 (defun org-sync-gitlab-fetch-buglist (last-update)
@@ -63,7 +67,7 @@
   (let
       ((jsonBugs (org-sync-gitlab-request
 	      "GET"
-	      (concat org-sync-base-url "issues?per_page=100"))))
+	      (concat (org-sync-gitlab-api-url) "issues?per_page=100"))))
   `(:title "Tasks"
 	   :url ,org-sync-base-url
 	   :bugs ,(mapcar 'org-sync-gitlab-json-to-bug jsonBugs)

--- a/org-sync.el
+++ b/org-sync.el
@@ -163,6 +163,8 @@
 (defvar org-sync-backend-alist
   '(("github.com/\\(?:repos/\\)?[^/]+/[^/]+" . org-sync-github-backend)
     ("bitbucket.org/[^/]+/[^/]+"             . org-sync-bb-backend)
+    ;;TODO make this use the org-sync-gitlab-domain
+    ("gitlab.com"                            . org-sync-gitlab-backend)
     ("/projects/[^/]+"                       . org-sync-rmine-backend)
     ("rememberthemilk.com"                   . org-sync-rtm-backend))
   "Alist of url patterns and corresponding org-sync backends.")


### PR DESCRIPTION
This should implement #20 .

This backend only supports basic synchronization for now.
Components, versions and milestones are ignored.

 You must set the `org-sync-gitlab-auth-token` before you can sync.

 If you are not using 'gitlab.com' you can change the domain with
 `org-sync-gitlab-domain`

There is still work to be done but the basic functionality is there and is is quite usable. 

BTW #31 should probably be closed.