### PR TITLE
Fix parsing of PROPERTIES drawer

### DIFF
--- a/org-sync.el
+++ b/org-sync.el
@@ -452,7 +452,7 @@ Return ELEM if it was added, nil otherwise."
    (stringp (org-sync-headline-url elem))))
 
 (defun org-sync-property-drawer-to-alist (drawer)
-  "Return the alist of all key value pairs."
+  "Find the PROPERTIES drawer and return all key value pairs as an alist."
   (org-element-map drawer
                    'node-property
                    (lambda (x) (cons (org-element-property :key x)
@@ -501,9 +501,7 @@ Return ELEM if it was added, nil otherwise."
          (title (car (org-element-property :title h)))
          (section (org-element-contents (car (org-element-contents h))))
          (headline-alist (org-sync-property-drawer-to-alist
-                          (car
-                           (org-element-contents
-                            (car (org-element-contents h))))))
+                          (car (org-element-contents h))))
          (ctime (org-sync-parse-date (cdr (assoc "date-creation" headline-alist))))
          (mtime (org-sync-parse-date (cdr (assoc "date-modification" headline-alist))))
          desc


### PR DESCRIPTION
(car org-elements-contents h) will get the first part of h and normally when the
PROPERTIES drawer is the first thing after the heading title we can get the
first of the first section and it will be the properties drawer (first heading,
then content of heading then in that we have the drawer). However, if there is a
DEADLINE or SCHEDULE in between we will get that instead. By not going so deep
and instead passing in the entire content of the section into
org-sync-property-drawer-to-alist we let it recursively search through for the
node-property list (what org-element calls the PROPERTIES drawer).

We're much less strict about where the PROPERTIES drawer goes which I think is
generally a good thing. It's certainly a good thing that it allows us to have a
SCHEDULE / DEADLINE line just under the heading. I hope this doesn't break
something else though.

Fixes #36.