### PR TITLE
Using the correct method when creating new bug

### DIFF
--- a/org-sync-gitlab.el
+++ b/org-sync-gitlab.el
@@ -116,7 +116,7 @@
       (cond
        ;; new bug (no id)
        ((null id)
-        (org-sync-gitlab-request-json
+        (org-sync-gitlab-request
          "POST"
          (concat (org-sync-gitlab-api-url)
                  issuePath)


### PR DESCRIPTION
`org-sync-gitlab-request` without the `json`