### PR TITLE
Fix non-determinism after sync; use issue id to resolve ties

### DIFF
--- a/test/compare-test.el
+++ b/test/compare-test.el
@@ -1,0 +1,14 @@
+(require 'org-sync)
+
+(ert-deftest test-key-to-comparator ()
+  (defun my-key (s)
+    ; sort by decreasing length and then lexicographically
+    `(
+      (,(length s) . (=       . >))
+      (,s          . (string= . string<))))
+
+  (defun predicate (a b)
+    (funcall (key-to-comparator 'my-key) a b))
+
+  (should (equal '("loooooong" "emacs" "hello" "a")
+                 (sort '("a" "emacs" "loooooong" "hello") 'predicate))))


### PR DESCRIPTION
Ok I think I figured that out... https://github.com/arbox/org-sync/issues/55

As a byproduct it's possible now to specify arbitrary key (e.g. you might want to sort by creation date only). But frankly I don't really like code I got as a result, so happy if you suggest a way to improve it..